### PR TITLE
Check for 0 columns in design.load before sampling item parameters

### DIFF
--- a/R/sim_items.R
+++ b/R/sim_items.R
@@ -10,7 +10,12 @@
 #' @return
 sim.items <- function(design.load, K, nb, load.range, int.range) {
   design.mat <- create.design.mat(K=K, nb=nb)
-
+  
+  stopifnot(
+    "All traits must be measured by at least one item." =
+    !any(apply(design.load, 2, function (x) all(x == 0)))
+  )
+  
   if(nb > 1) {
     repeat{
       loads <- runif(K*nb, min=min(load.range), max=max(load.range))


### PR DESCRIPTION
The condition

qr(design.mat %*% load.mat)$rank==ncol(design.load)

can never be met if a column of design.load comprises only 0s. The user runs in an endless loop. Especially, when this function is used in parallel, being stuck in a repeat-loop makes debugging much harder. So, I added an error message.